### PR TITLE
change node traversal mode

### DIFF
--- a/dogtail/config.py
+++ b/dogtail/config.py
@@ -112,6 +112,10 @@ class _Config(object):
 
     logDebugToStdOut (boolean):
     Whether to print log output to console or not (default True).
+
+    reversed (boolean):
+    When traversing nodes, is reverse iteration adopted?(default False).
+
     """
     @property
     def scriptName(self):
@@ -156,7 +160,10 @@ class _Config(object):
         'checkForA11y': True,
 
         # Logging
-        'logDebugToFile': True
+        'logDebugToFile': True,
+
+        # reversed
+        'reversed': False
     }
 
     options = {}

--- a/dogtail/tree.py
+++ b/dogtail/tree.py
@@ -878,7 +878,10 @@ class Node(object):
             pred = lambda n: orig_pred(n) and \
                              n.getState().contains(pyatspi.STATE_SHOWING)
         if not recursive:
-            cIter = iter(self)
+            if config.reversed is False:
+                cIter = iter(self)
+            else:
+                cIter = reversed(self)
             while True:
                 try:
                     child = next(cIter)


### PR DESCRIPTION
The node traversal method is changed from forward to reverse because of two points: 1. The application node you want to obtain with Dogtail is normally the latest started application, and the node application will be at the bottom of the sniff tree, so you can obtain objects as quickly as possible in reverse; 2. For applications that do not support a11y, especially Java GUI applications, a node will be formed in the dogtail traversal node, resulting in a long time of blocking, or even no downward traversal. reverse traversal of the node can avoid this situation.
![sniff](https://user-images.githubusercontent.com/45532217/199879254-3117b11b-a40b-4b50-8e71-db64231dc576.png)
